### PR TITLE
Adjust permissions so Create release PR can generate the PR.

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -14,6 +14,10 @@
 
 name: Create Release PR
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ permissions:
 on:
   push:
     branches:
-      - main
+      - MarkDaoust-patch-2
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ permissions:
 on:
   push:
     branches:
-      - MarkDaoust-patch-2
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Tested:

Chaged "on" branch to **this branch** (in the second commit), and it generated this PR:  https://github.com/google-gemini/deprecated-generative-ai-js/pull/465

Seems like it worked.